### PR TITLE
Support engine.io-client versions > 1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,34 +1,51 @@
-// XMLHttpRequest to override.
-var xhrPath = '../socket.io-client/node_modules/engine.io-client/node_modules/xmlhttprequest';
-
-//Require it for the first time to store it in the require.cache
-require(xhrPath);
-
-//Get the resolved filename which happens to be the key of the module in the cache object
-var xhrName = require.resolve(xhrPath);
-
-//Get the cached xhr module
-var cachedXhr = require.cache[xhrName].exports;
+var debug = require('debug')('socket.io-client-cookies');
 
 //Cookies to be applied in the xhr
 var cookies;
 
-////Monkey Patch
-var newXhr = function () {
-    cachedXhr.apply(this, arguments);
-    this.setDisableHeaderCheck(true);
+function patchXHR(xhrPath) {
+    //Require it for the first time to store it in the require.cache
+    require(xhrPath);
+    
+    //Get the resolved filename which happens to be the key of the module in the cache object
+    var xhrName = require.resolve(xhrPath);
+    
+    //Get the cached xhr module
+    var cachedXhr = require.cache[xhrName].exports;
+    
+    ////Monkey Patch
+    var newXhr = function () {
+        cachedXhr.apply(this, arguments);
+        this.setDisableHeaderCheck(true);
+        
+        var stdOpen = this.open;
+        this.open = function () {
+            stdOpen.apply(this, arguments);
+            this.setRequestHeader('Cookie', cookies);
+        }
+    };
+    
+    newXhr.XMLHttpRequest = newXhr;
+    require.cache[xhrName].exports = newXhr;
+}
 
-    var stdOpen = this.open;
-    this.open = function () {
-        stdOpen.apply(this, arguments);
-        this.setRequestHeader('Cookie', cookies);
+try {
+    patchXHR('../socket.io-client/node_modules/engine.io-client/node_modules/xmlhttprequest');
+} catch (e) {
+    debug('Failed to patch engine.io v1.5.x.  If you are running a later version you can ignore this', e);
+}
 
-    }
-};
+try {
+    patchXHR('../socket.io-client/node_modules/engine.io-client/lib/xmlhttprequest');
+} catch (e) {
+    debug('Failed to patch engine.io v1.6.x.  If you are running an earlier version you can ignore this', e);
+}
 
-newXhr.XMLHttpRequest = newXhr;
-require.cache[xhrName].exports = newXhr;
-module.exports = newXhr;
+try {
+    patchXHR('../socket.io-client/node_modules/engine.io-client/node_modules/xmlhttprequest-ssl');
+} catch (e) {
+    debug('Failed to patch engine.io v1.6.x.  If you are running an earlier version you can ignore this', e);
+}
 
 module.exports.setCookies = function(newCookies) {
     cookies = newCookies;

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/rakeshok/socket.io-client-cookie/issues"
   },
-  "homepage": "https://github.com/rakeshok/socket.io-client-cookie"
+  "homepage": "https://github.com/rakeshok/socket.io-client-cookie",
+  "dependencies": {
+    "debug": "^2.2.0"
+  }
 }


### PR DESCRIPTION
I was trying to use this project with socket.io 1.4 (and engine.io 1.6) and noticed that it didn't work right.  It looks like the source of the XHR support has changed.

Here are some changes that make the project compatible with both socket 1.3 and socket.io 1.4 too. 
